### PR TITLE
fix: remove deprecated import

### DIFF
--- a/concept/concept.py
+++ b/concept/concept.py
@@ -8,7 +8,11 @@ import json
 import pkg_resources
 from xblock.core import XBlock
 from xblock.fields import Integer, Scope, String
-from xblock.fragment import Fragment
+try:
+    from web_fragments.fragment import Fragment
+except:
+    # for backwards compatibility with quince and prior releases
+    from xblock.fragment import Fragment
 
 import requests
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def is_requirement(line):
 
 setup(
     name='concept-xblock',
-    version='0.3.2',
+    version='0.3.3',
     description='concept XBlock',   # TODO: write a better description.
     long_description=open('README.md', encoding='utf-8').read(),  # pylint: disable=consider-using-with
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Description
This replace `xblock.fragment` with `web_fragments.fragment`. `xblock.fragment` was [removed as of 2024-02-26](https://docs.openedx.org/projects/xblock/en/latest/changelog.html#id2). If this xblock is used in a course, the entire course will fail to load.